### PR TITLE
fix-default-command-hotkey

### DIFF
--- a/packwiz/config/yosbr/options.txt
+++ b/packwiz/config/yosbr/options.txt
@@ -101,7 +101,7 @@ key_key.inventory:key.keyboard.e
 key_key.chat:key.keyboard.t
 key_key.playerlist:key.keyboard.tab
 key_key.pickItem:key.mouse.middle
-key_key.command:key.keyboard.keypad.divide
+key_key.command:key.keyboard.slash
 key_key.socialInteractions:key.keyboard.p
 key_key.screenshot:key.keyboard.f2
 key_key.togglePerspective:key.keyboard.f5


### PR DESCRIPTION
Fix the default hotkey from numpad slash to vanilla slash