### PR TITLE
Prioritize skyblocker recipies over vanilla ones

### DIFF
--- a/packwiz/config/yosbr/config/roughlyenoughitems/config.json5
+++ b/packwiz/config/yosbr/config/roughlyenoughitems/config.json5
@@ -159,6 +159,7 @@
 			"categorySettings": {
 				"filteringQuickCraftCategories": { },
 				"categoryOrdering": [
+					"skyblocker:skyblock",
 					"minecraft:plugins/crafting",
 					"minecraft:plugins/smelting",
 					"minecraft:plugins/smoking",
@@ -179,7 +180,6 @@
 					"minecraft:plugins/wax_scraping",
 					"minecraft:plugins/oxidizing",
 					"minecraft:plugins/oxidation_scraping",
-					"skyblocker:skyblock",
 					"roughlyenoughitems:plugins/information",
 					"minecraft:plugins/tag"
 				],


### PR DESCRIPTION
One of the annoying groups is anvil, it has useless enchantment recipes for any armor/tool.

Before and after:
<img width="687" alt="image" src="https://github.com/user-attachments/assets/d2778e34-7000-4fcd-b011-9606f3dd0d8a" />
<img width="648" alt="image" src="https://github.com/user-attachments/assets/de0130e2-9de7-4165-bfa4-4c0d0b5a3b1a" />
