### PR TITLE
Update REI Config

### DIFF
--- a/packwiz/config/yosbr/config/roughlyenoughitems/config.json5
+++ b/packwiz/config/yosbr/config/roughlyenoughitems/config.json5
@@ -164,6 +164,7 @@
 				"categoryOrdering": [
 					"skyblocker:skyblock_crafting",
 					"skyblocker:skyblock_forge",
+					"skyblocker:skyblock_info",
 					"minecraft:plugins/crafting",
 					"minecraft:plugins/smelting",
 					"minecraft:plugins/smoking",
@@ -187,7 +188,30 @@
 					"roughlyenoughitems:plugins/information",
 					"minecraft:plugins/tag"
 				],
-				"hiddenCategories": []
+				"hiddenCategories": [
+					"minecraft:plugins/crafting",
+					"minecraft:plugins/smelting",
+					"minecraft:plugins/smoking",
+					"minecraft:plugins/blasting",
+					"minecraft:plugins/campfire",
+					"minecraft:plugins/stone_cutting",
+					"minecraft:plugins/fuel",
+					"minecraft:plugins/brewing",
+					"minecraft:plugins/composting",
+					"minecraft:plugins/stripping",
+					"minecraft:plugins/smithing",
+					"minecraft:plugins/anvil",
+					"minecraft:plugins/beacon_base",
+					"minecraft:plugins/beacon_payment",
+					"minecraft:plugins/tilling",
+					"minecraft:plugins/pathing",
+					"minecraft:plugins/waxing",
+					"minecraft:plugins/wax_scraping",
+					"minecraft:plugins/oxidizing",
+					"minecraft:plugins/oxidation_scraping",
+					"roughlyenoughitems:plugins/information",
+					"minecraft:plugins/tag"
+				]
 			}
 		},
 		"filtering": {


### PR DESCRIPTION
Moves the new Skyblock Info category (https://github.com/SkyblockerMod/Skyblocker/commit/ab85baafd92ea6f46a879005adb5a40629bbd64d) above the vanilla categories.
Hides all of the vanilla categories since all non-Skyblock items are removed.