### PR TITLE
Disable REI Enchanted Books and Potion Collapsible Categories

### DIFF
--- a/packwiz/config/yosbr/config/roughlyenoughitems/collapsible.json5
+++ b/packwiz/config/yosbr/config/roughlyenoughitems/collapsible.json5
@@ -1,4 +1,7 @@
 {
-	"disabledGroups": [],
+	"disabledGroups": [
+		"roughlyenoughitems:enchanted_book",
+		"roughlyenoughitems:potion"
+	],
 	"customGroups": []
 }


### PR DESCRIPTION
These categories make searching for enchanted books/potions harder, even if the Skyblocker Collapsible Categories (https://github.com/SkyblockerMod/Skyblocker/pull/1475) are enabled. Disabling them is the best way to fix that since REI plugins can't disable other collapsible categories, other than overwriting them.